### PR TITLE
feat(reader): auto-play narration with remembered preference (card #32)

### DIFF
--- a/components/BookReader/BookReader.tsx
+++ b/components/BookReader/BookReader.tsx
@@ -78,6 +78,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
     const setNarrationPlaying = useNarrationStore(s => s.setNarrationPlaying);
     const setLoadingAudio = useNarrationStore(s => s.setLoadingAudio);
     const setRateLimited = useNarrationStore(s => s.setRateLimited);
+    const setAutoPlayEnabled = useNarrationStore(s => s.setAutoPlayEnabled);
 
     const pages = useMemo(() =>
         (sectionsProp && sectionsProp.length > 0)
@@ -113,9 +114,10 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
     }, [autoAdvancePages, currentIndex, pages.length, setNarrationPlaying]);
 
     // --- AUDIO GENERATION ---
-    const generateAndLoadAudio = useCallback(async (pageIndex: number, pageText: string) => {
+    // Returns true when audio is loaded into the player and ready to play.
+    const generateAndLoadAudio = useCallback(async (pageIndex: number, pageText: string): Promise<boolean> => {
         if (!isNarrationEnabled || !pageText || pageText === "Loading story..." || isRateLimited) {
-            return;
+            return false;
         }
 
         const cacheKey = `${storyIdRef.current}-${pageIndex}`;
@@ -136,7 +138,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
                 }
                 await playerRef.current.load(cachedAudio);
                 setLoadingAudio(false);
-                return;
+                return true;
             }
 
             // Generate new audio
@@ -174,6 +176,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
             }
             await playerRef.current.load(result.audio);
             setLoadingAudio(false);
+            return true;
         } catch (error) {
             console.error('Error generating audio:', error);
             trackEvent(AnalyticsEvents.NARRATION_FAILED, {
@@ -233,10 +236,12 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
             }
 
             setLoadingAudio(false);
+            return false;
         }
     }, [isNarrationEnabled, isRateLimited, setLoadingAudio, setRateLimited, handlePlaybackComplete]);
 
-    const handlePlay = useCallback(async () => {
+    // Low-level: play whatever audio is currently loaded in the player.
+    const playLoadedAudio = useCallback(async () => {
         if (!playerRef.current || isLoadingAudio) {
             return;
         }
@@ -286,7 +291,31 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         }
     }, [isLoadingAudio, setNarrationPlaying, currentIndex]);
 
-    const handlePause = useCallback(async () => {
+    // User pressed Play: (re)enable the auto-play preference, generate audio for
+    // the current page if it wasn't pre-loaded (because auto-play was off), then
+    // play. Re-enabling the preference resumes auto-play on subsequent pages.
+    const handlePlay = useCallback(async () => {
+        setAutoPlayEnabled(true);
+        if (isLoadingAudio) {
+            return;
+        }
+        if (!playerRef.current) {
+            const currentPage = pages[currentIndex];
+            if (!currentPage?.text) {
+                return;
+            }
+            const ready = await generateAndLoadAudio(currentIndex, currentPage.text);
+            if (!ready) {
+                return;
+            }
+        }
+        await playLoadedAudio();
+    }, [isLoadingAudio, pages, currentIndex, generateAndLoadAudio, playLoadedAudio, setAutoPlayEnabled]);
+
+    // Low-level: stop playback without changing the auto-play preference.
+    // Used when navigating between pages (we still want auto-play to resume on
+    // the next page if the user hasn't opted out).
+    const stopPlayback = useCallback(async () => {
         if (!playerRef.current) {
             return;
         }
@@ -294,10 +323,6 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         try {
             await playerRef.current.pause();
             setNarrationPlaying(false);
-            trackEvent(AnalyticsEvents.NARRATION_PAUSED, {
-                story_id: storyIdRef.current,
-                page_index: currentIndex,
-            });
         } catch (error) {
             // Log pause failure with context
             logger.error(
@@ -333,6 +358,17 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         }
     }, [setNarrationPlaying, currentIndex]);
 
+    // User pressed Pause: opt out of auto-play (persisted) so no further TTS is
+    // generated on subsequent pages until they press Play again, then stop.
+    const handlePause = useCallback(async () => {
+        setAutoPlayEnabled(false);
+        await stopPlayback();
+        trackEvent(AnalyticsEvents.NARRATION_PAUSED, {
+            story_id: storyIdRef.current,
+            page_index: currentIndex,
+        });
+    }, [setAutoPlayEnabled, stopPlayback, currentIndex]);
+
     const handleRetry = useCallback(() => {
         trackEvent(AnalyticsEvents.NARRATION_RETRIED, { page_index: currentIndex });
         // Clear error state and retry loading audio for current page
@@ -348,26 +384,27 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
     }, [currentIndex, pages, generateAndLoadAudio]);
 
     const goNext = useCallback(() => {
-        // Pause audio when navigating
+        // Stop current audio when navigating, but keep the auto-play preference
+        // so the next page narrates automatically (if the user hasn't opted out).
         if (playerRef.current && isNarrationPlaying) {
-            void handlePause();
+            void stopPlayback();
         }
 
         if (currentIndex < pages.length) {
             setCurrentIndex(prev => prev + 1);
         }
-    }, [currentIndex, pages.length, isNarrationPlaying, handlePause]);
+    }, [currentIndex, pages.length, isNarrationPlaying, stopPlayback]);
 
     const goPrev = useCallback(() => {
-        // Pause audio when navigating
+        // Stop current audio when navigating (preference preserved — see goNext).
         if (playerRef.current && isNarrationPlaying) {
-            void handlePause();
+            void stopPlayback();
         }
 
         if (currentIndex > 0) {
             setCurrentIndex(prev => prev - 1);
         }
-    }, [currentIndex, isNarrationPlaying, handlePause]);
+    }, [currentIndex, isNarrationPlaying, stopPlayback]);
 
     const handleRestartStory = () => {
         trackEvent(AnalyticsEvents.STORY_END_ACTION, { action: 'read_again' });
@@ -430,9 +467,19 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         // Reset image loading state on page change
         setIsLoadingImage(false);
 
+        // Auto-play: when the auto-play preference is on, generate the page's
+        // narration and start it automatically. When off (the user paused), we
+        // skip TTS entirely until they press Play again. Read the preference via
+        // getState() so toggling it doesn't re-run this effect mid-page.
         const currentPage = pages[currentIndex];
-        if (currentPage && currentPage.text) {
-            void generateAndLoadAudio(currentIndex, currentPage.text);
+        if (currentPage && currentPage.text && useNarrationStore.getState().isAutoPlayEnabled) {
+            void (async () => {
+                const ready = await generateAndLoadAudio(currentIndex, currentPage.text);
+                // Bail if the user navigated away or opted out while audio loaded.
+                if (!cancelled && ready && useNarrationStore.getState().isAutoPlayEnabled) {
+                    await playLoadedAudio();
+                }
+            })();
         }
 
         // Lazy image fetching: if page has illustrationPrompt but no imageUrl, generate on demand
@@ -462,7 +509,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         return () => {
             cancelled = true;
         };
-    }, [currentIndex, pages, generateAndLoadAudio, story.storyId, updatePageImage, isEndPage]);
+    }, [currentIndex, pages, generateAndLoadAudio, playLoadedAudio, story.storyId, updatePageImage, isEndPage]);
 
     // Track story_opened once on mount
     useEffect(() => {

--- a/src/stores/__tests__/narrationStore.test.ts
+++ b/src/stores/__tests__/narrationStore.test.ts
@@ -1,0 +1,52 @@
+import { useNarrationStore } from '@/src/stores/narrationStore';
+
+/**
+ * Tests for the auto-play narration preference (card #32).
+ *
+ * Key invariant: isAutoPlayEnabled is a remembered user preference, so it must
+ * survive resetNarration() (called when starting a new story) — unlike the
+ * transient playback fields, which reset.
+ */
+describe('narrationStore – auto-play preference', () => {
+  beforeEach(() => {
+    // Reset to a known baseline between tests.
+    useNarrationStore.setState({
+      isNarrationEnabled: true,
+      isNarrationPlaying: false,
+      isLoadingAudio: false,
+      autoAdvancePages: false,
+      isRateLimited: false,
+      rateLimitResetTime: null,
+      isAutoPlayEnabled: true,
+    });
+  });
+
+  it('defaults to auto-play enabled', () => {
+    expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(true);
+  });
+
+  it('setAutoPlayEnabled toggles the preference', () => {
+    useNarrationStore.getState().setAutoPlayEnabled(false);
+    expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(false);
+
+    useNarrationStore.getState().setAutoPlayEnabled(true);
+    expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(true);
+  });
+
+  it('resetNarration preserves the auto-play preference but clears transient state', () => {
+    // Simulate an in-progress story where the user opted out of auto-play.
+    useNarrationStore.setState({
+      isAutoPlayEnabled: false,
+      isNarrationPlaying: true,
+      autoAdvancePages: true,
+    });
+
+    useNarrationStore.getState().resetNarration();
+
+    const state = useNarrationStore.getState();
+    expect(state.isAutoPlayEnabled).toBe(false); // preference remembered
+    expect(state.isNarrationPlaying).toBe(false); // transient: reset
+    expect(state.autoAdvancePages).toBe(false);   // transient: reset
+    expect(state.isNarrationEnabled).toBe(true);
+  });
+});

--- a/src/stores/narrationStore.ts
+++ b/src/stores/narrationStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 // ---------------------------------------------------------------------------
 // USAGE: Always use per-field selectors, NOT wholesale destructuring
@@ -31,12 +32,22 @@ export interface NarrationState {
   isRateLimited: boolean;
   rateLimitResetTime: number | null;
 
+  // --- Preferences (persisted) ---
+  /**
+   * Whether narration should auto-play when a story page is displayed.
+   * Toggled by the Play (on) / Pause (off) controls and remembered across
+   * stories and app launches. When false, no TTS is generated on page change
+   * until the user presses Play again.
+   */
+  isAutoPlayEnabled: boolean;
+
   // --- Actions: Narration ---
   setNarrationEnabled: (enabled: boolean) => void;
   setNarrationPlaying: (playing: boolean) => void;
   setLoadingAudio: (loading: boolean) => void;
   setAutoAdvancePages: (auto: boolean) => void;
   setRateLimited: (limited: boolean, resetTime?: number) => void;
+  setAutoPlayEnabled: (enabled: boolean) => void;
 
   // --- Actions: Reset ---
   resetNarration: () => void;
@@ -48,51 +59,66 @@ export interface NarrationState {
 
 const useNarrationStore = create<NarrationState>()(
   devtools(
-    (set, get) => ({
+    persist(
+      (set, get) => ({
 
-      // --- Initial state ---
-      isNarrationEnabled: true,
-      isNarrationPlaying: false,
-      isLoadingAudio: false,
-      autoAdvancePages: false,
-      isRateLimited: false,
-      rateLimitResetTime: null,
+        // --- Initial state ---
+        isNarrationEnabled: true,
+        isNarrationPlaying: false,
+        isLoadingAudio: false,
+        autoAdvancePages: false,
+        isRateLimited: false,
+        rateLimitResetTime: null,
 
-      // -----------------------------------------------------------------------
-      // NARRATION ACTIONS
-      // -----------------------------------------------------------------------
+        // --- Preferences (persisted) ---
+        isAutoPlayEnabled: true,
 
-      setNarrationEnabled: (enabled) => set({ isNarrationEnabled: enabled }),
+        // ---------------------------------------------------------------------
+        // NARRATION ACTIONS
+        // ---------------------------------------------------------------------
 
-      setNarrationPlaying: (playing) => set({ isNarrationPlaying: playing }),
+        setNarrationEnabled: (enabled) => set({ isNarrationEnabled: enabled }),
 
-      setLoadingAudio: (loading) => set({ isLoadingAudio: loading }),
+        setNarrationPlaying: (playing) => set({ isNarrationPlaying: playing }),
 
-      setAutoAdvancePages: (auto) => set({ autoAdvancePages: auto }),
+        setLoadingAudio: (loading) => set({ isLoadingAudio: loading }),
 
-      setRateLimited: (limited, resetTime?) => {
-        set({
-          isRateLimited: limited,
-          rateLimitResetTime: resetTime ?? null,
-          isNarrationEnabled: limited ? false : get().isNarrationEnabled,
-        });
-      },
+        setAutoAdvancePages: (auto) => set({ autoAdvancePages: auto }),
 
-      // -----------------------------------------------------------------------
-      // RESET ACTIONS
-      // -----------------------------------------------------------------------
+        setRateLimited: (limited, resetTime?) => {
+          set({
+            isRateLimited: limited,
+            rateLimitResetTime: resetTime ?? null,
+            isNarrationEnabled: limited ? false : get().isNarrationEnabled,
+          });
+        },
 
-      resetNarration: () => {
-        set({
-          isNarrationEnabled: true,
-          isNarrationPlaying: false,
-          isLoadingAudio: false,
-          autoAdvancePages: false,
-          isRateLimited: false,
-          rateLimitResetTime: null,
-        });
-      },
-    })
+        setAutoPlayEnabled: (enabled) => set({ isAutoPlayEnabled: enabled }),
+
+        // ---------------------------------------------------------------------
+        // RESET ACTIONS
+        // ---------------------------------------------------------------------
+
+        resetNarration: () => {
+          // Note: isAutoPlayEnabled is intentionally NOT reset — the auto-play
+          // preference is remembered across stories and app launches.
+          set({
+            isNarrationEnabled: true,
+            isNarrationPlaying: false,
+            isLoadingAudio: false,
+            autoAdvancePages: false,
+            isRateLimited: false,
+            rateLimitResetTime: null,
+          });
+        },
+      }),
+      {
+        name: 'narration-preferences',
+        storage: createJSONStorage(() => AsyncStorage),
+        // Only persist user preferences, not transient playback state.
+        partialize: (state) => ({ isAutoPlayEnabled: state.isAutoPlayEnabled }),
+      }
+    )
   )
 );
 


### PR DESCRIPTION
## What & why

Implements **card #32 — Auto-play audio with TTS**. Previously TTS was generated on each page load but only played when the user tapped Play. Now narration starts automatically and the on/off choice is remembered.

Maps to the card's acceptance criteria:

1. ✅ **Auto-play when a story is first displayed** — on each page, if auto-play is on, narration is generated and started automatically.
2. ✅ **Continues until page end or pause** — plays through the page; existing `autoAdvancePages` still governs moving to the next page.
3. ✅ **Pause stops all future TTS** — pausing sets the preference off, and the page-change effect skips TTS generation entirely while off.
4. ✅ **No TTS until Play is pressed again** — pressing Play re-enables the preference, generates audio for the current page, and resumes auto-play on later pages.
5. ✅ **Preference remembered for new stories** — persisted via `zustand/persist` + `AsyncStorage`; `resetNarration()` (new-story flow) intentionally preserves it.

## Changes

- **`src/stores/narrationStore.ts`** — new persisted `isAutoPlayEnabled` preference (default on). Wrapped the store in `persist` with `partialize` so only the preference is stored, not transient playback state. `resetNarration` preserves the preference.
- **`components/BookReader/BookReader.tsx`**
  - Page-change effect generates **and** auto-plays when the preference is on; reads it via `getState()` so toggling doesn't re-run the effect mid-page.
  - `generateAndLoadAudio` now returns a `boolean` (ready/not).
  - Split playback into **low-level** (`playLoadedAudio`, `stopPlayback`) vs **user-intent** (`handlePlay`, `handlePause`) handlers. Page navigation uses `stopPlayback`, so moving between pages no longer flips the preference — only the Play/Pause buttons do.
- **`src/stores/__tests__/narrationStore.test.ts`** — covers default, toggle, and reset-preserves-preference.

## Testing

- `npm run validate` (type-check + jest) green — **27 tests pass**, incl. 3 new.

## Notes / caveats for review

- **UX decision:** per the card, the Play/Pause buttons double as the persisted auto-play toggle (Pause = "stop and don't auto-play", Play = "resume and auto-play"). There's no separate toggle control. If you'd prefer an explicit auto-play switch distinct from a one-off pause, easy to add.
- **Browser autoplay policy:** programmatic `play()` without a recent user gesture can be blocked on web. The existing play-error handling surfaces a retry, so it degrades to the old manual-play behavior in that case. Native (expo-audio) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)