### PR TITLE
fix(reader): stop BookReader auto-play effect from looping infinitely

### DIFF
--- a/components/BookReader/BookReader.tsx
+++ b/components/BookReader/BookReader.tsx
@@ -241,8 +241,12 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
     }, [isNarrationEnabled, isRateLimited, setLoadingAudio, setRateLimited, handlePlaybackComplete]);
 
     // Low-level: play whatever audio is currently loaded in the player.
+    // Read isLoadingAudio via getState() rather than subscribing: this keeps the
+    // callback identity stable so the page-change effect (which lists this in its
+    // deps AND toggles isLoadingAudio via generateAndLoadAudio) can't feed back on
+    // itself and trigger "Maximum update depth exceeded".
     const playLoadedAudio = useCallback(async () => {
-        if (!playerRef.current || isLoadingAudio) {
+        if (!playerRef.current || useNarrationStore.getState().isLoadingAudio) {
             return;
         }
 
@@ -289,7 +293,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
                 playerRef.current = null;
             }
         }
-    }, [isLoadingAudio, setNarrationPlaying, currentIndex]);
+    }, [setNarrationPlaying, currentIndex]);
 
     // User pressed Play: (re)enable the auto-play preference, generate audio for
     // the current page if it wasn't pre-loaded (because auto-play was off), then

--- a/components/__tests__/BookReader-test.tsx
+++ b/components/__tests__/BookReader-test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react-native';
+
+import BookReader from '@/components/BookReader/BookReader';
+import { useStoryStore } from '@/src/stores/storyStore';
+import { useNarrationStore } from '@/src/stores/narrationStore';
+import { createNarrationPlayer } from '@/services/narration';
+import elevenLabsService from '@/services/elevenLabsService';
+import audioCache from '@/services/narration/audioCache';
+
+// ---------------------------------------------------------------------------
+// Component tests for BookReader auto-play wiring (Fizzy card #39).
+//
+// These exercise the page-change effect in BookReader.tsx that the store-level
+// tests (narrationStore.test.ts) can't reach. They cover the card's acceptance
+// criteria — auto-play on display, pause stops future TTS, no TTS until Play —
+// AND lock in the fix for the "Maximum update depth exceeded" infinite loop hit
+// when opening a book from the bookshelf: the effect listed playLoadedAudio in
+// its deps while playLoadedAudio depended on isLoadingAudio, which the effect
+// itself toggled — so it re-ran forever. The regression test below asserts the
+// narration player is driven a bounded number of times per page.
+// ---------------------------------------------------------------------------
+
+// Replace the narration player with controllable jest.fns (the global mock in
+// jest.setup.js lacks pause/cleanup, which BookReader calls).
+jest.mock('@/services/narration', () => ({
+    createNarrationPlayer: jest.fn(() => ({
+        load: jest.fn(() => Promise.resolve()),
+        play: jest.fn(() => Promise.resolve()),
+        pause: jest.fn(() => Promise.resolve()),
+        cleanup: jest.fn(),
+    })),
+}));
+
+// Keep TTS off the network; return a valid-looking audio buffer (> 100 bytes).
+jest.mock('@/services/elevenLabsService', () => ({
+    __esModule: true,
+    default: {
+        generateSpeech: jest.fn(() => Promise.resolve({ audio: new Uint8Array(200) })),
+    },
+}));
+
+// No lazy image generation in these tests.
+jest.mock('@/services/storyGenerationService', () => ({
+    __esModule: true,
+    default: {
+        generatePageImage: jest.fn(() => Promise.resolve(null)),
+    },
+}));
+
+// Analytics is fire-and-forget; stub it and echo event names back as strings.
+jest.mock('@/src/utils/analytics', () => ({
+    trackEvent: jest.fn(),
+    AnalyticsEvents: new Proxy(
+        {},
+        { get: (_t, prop) => (typeof prop === 'string' ? prop : undefined) }
+    ),
+}));
+
+const generateSpeechMock = elevenLabsService.generateSpeech as jest.Mock;
+const createNarrationPlayerMock = createNarrationPlayer as jest.Mock;
+
+/** The single NarrationPlayer instance BookReader created this render, if any. */
+const currentPlayer = () => createNarrationPlayerMock.mock.results[0]?.value;
+
+const SECTIONS = [
+    { text: 'Once upon a time there was a brave little fox.', imageUrl: null },
+    { text: 'The fox found a glowing acorn under the old oak tree.', imageUrl: null },
+];
+
+/** Seed the story store the way the bookshelf screen does before mounting BookReader. */
+const seedStory = () => {
+    useStoryStore.setState({
+        story: { content: null, sections: SECTIONS, storyId: null, name: 'The Brave Fox' },
+    });
+};
+
+const resetNarration = (overrides = {}) => {
+    useNarrationStore.setState({
+        isNarrationEnabled: true,
+        isNarrationPlaying: false,
+        isLoadingAudio: false,
+        autoAdvancePages: false,
+        isRateLimited: false,
+        rateLimitResetTime: null,
+        isAutoPlayEnabled: true,
+        ...overrides,
+    });
+};
+
+describe('BookReader – auto-play behavior (card #39)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        audioCache.clear();
+        seedStory();
+        resetNarration();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('auto-plays narration on the opening page when auto-play is enabled', async () => {
+        render(<BookReader onBack={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+        });
+        expect(generateSpeechMock).toHaveBeenCalledWith(
+            SECTIONS[0].text,
+            undefined,
+            expect.objectContaining({ model_id: 'eleven_flash_v2_5' })
+        );
+
+        await waitFor(() => {
+            expect(currentPlayer().play).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('does not loop: drives the player exactly once per page (regression for max-update-depth)', async () => {
+        // With the pre-fix code this effect re-ran indefinitely (toggling
+        // isLoadingAudio churned playLoadedAudio's identity), throwing
+        // "Maximum update depth exceeded" and calling play() over and over.
+        render(<BookReader onBack={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(currentPlayer().play).toHaveBeenCalledTimes(1);
+        });
+
+        // Give any runaway re-renders a chance to pile up, then confirm the
+        // counts stayed bounded.
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+        expect(currentPlayer().play).toHaveBeenCalledTimes(1);
+        expect(currentPlayer().load).toHaveBeenCalledTimes(1);
+    });
+
+    it('pausing opts out so a later page change generates no narration', async () => {
+        render(<BookReader onBack={jest.fn()} />);
+
+        // Wait for the opening page to auto-play.
+        await waitFor(() => {
+            expect(currentPlayer().play).toHaveBeenCalledTimes(1);
+        });
+        expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+
+        // Pause: turns the auto-play preference off and stops playback.
+        fireEvent.press(screen.getByLabelText('Pause narration'));
+        await waitFor(() => {
+            expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(false);
+        });
+
+        // Turn the page — with auto-play off, no new TTS should be generated.
+        fireEvent.press(screen.getByText('›'));
+        await waitFor(() => {
+            expect(screen.getByText('Page 2 of 2')).toBeTruthy();
+        });
+
+        expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not narrate until Play is pressed when auto-play is disabled', async () => {
+        resetNarration({ isAutoPlayEnabled: false });
+        render(<BookReader onBack={jest.fn()} />);
+
+        // Let the page-change effect settle; it must not generate audio.
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(generateSpeechMock).not.toHaveBeenCalled();
+
+        // Pressing Play re-enables auto-play and generates/plays the page.
+        fireEvent.press(screen.getByLabelText('Play narration'));
+
+        await waitFor(() => {
+            expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+        });
+        await waitFor(() => {
+            expect(currentPlayer().play).toHaveBeenCalledTimes(1);
+        });
+        expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes "Maximum update depth exceeded" crash when opening a book from the bookshelf.
- Root cause: the page-change effect in `components/BookReader/BookReader.tsx` listed `playLoadedAudio` in its dependency array, while `playLoadedAudio` subscribed to `isLoadingAudio` — a value the effect itself toggles via `generateAndLoadAudio`. Each toggle changed the callback identity, re-running the effect in an infinite loop. Since narration and auto-play both default to on, it fired on every open.
- Fix: `playLoadedAudio` now reads `isLoadingAudio` via `useNarrationStore.getState()` instead of subscribing, keeping its identity stable and breaking the feedback loop (the guard also reads a fresher value).
- Adds component-level auto-play tests in `components/__tests__/BookReader-test.tsx` (Fizzy card #39), the previously-untested auto-play wiring.

## Test plan
- [x] `npx jest components/__tests__/BookReader-test.tsx` — 4 tests pass:
  - auto-plays narration on the opening page when enabled
  - regression: drives the narration player exactly once per page (max-update-depth guard)
  - pausing opts out so a later page change generates no TTS
  - no narration until Play is pressed when auto-play is disabled
- [x] Verified the regression test **fails** against the pre-fix code, then passes with the fix.
- [x] `npx tsc --noEmit` and `npx eslint` clean on changed files.
- [ ] Manual: open a saved book from the bookshelf and confirm it loads and narrates without crashing.

Relates to Fizzy card #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)