### PR TITLE
fix(reader): stop duplicate narration when opening a book from the bookshelf

### DIFF
--- a/components/BookReader/BookReader.tsx
+++ b/components/BookReader/BookReader.tsx
@@ -10,6 +10,7 @@ import {
     Animated
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useIsFocused } from '@react-navigation/native';
 import { Colors } from '@/constants/theme';
 import { styles } from './BookReader.style';
 import { useConversationStore } from '@/src/stores/conversationStore';
@@ -88,6 +89,13 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
                 : [{ text: "Loading story...", imageUrl: null }]),
         [sectionsProp, story.sections]
     );
+
+    // Whether this reader is on the currently-focused screen. A BookReader can
+    // stay mounted on an inactive tab — e.g. the Lab tab still holds the
+    // generated story (StoryScreen renders it whenever story.content is set,
+    // which opening a bookshelf book also populates). Only the focused reader is
+    // allowed to narrate, otherwise two instances auto-play at once.
+    const isFocused = useIsFocused();
 
     const [currentIndex, setCurrentIndex] = useState(0);
     const [audioError, setAudioError] = useState<string | null>(null);
@@ -476,7 +484,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         // skip TTS entirely until they press Play again. Read the preference via
         // getState() so toggling it doesn't re-run this effect mid-page.
         const currentPage = pages[currentIndex];
-        if (currentPage && currentPage.text && useNarrationStore.getState().isAutoPlayEnabled) {
+        if (currentPage && currentPage.text && isFocused && useNarrationStore.getState().isAutoPlayEnabled) {
             void (async () => {
                 const ready = await generateAndLoadAudio(currentIndex, currentPage.text);
                 // Bail if the user navigated away or opted out while audio loaded.
@@ -513,7 +521,15 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         return () => {
             cancelled = true;
         };
-    }, [currentIndex, pages, generateAndLoadAudio, playLoadedAudio, story.storyId, updatePageImage, isEndPage]);
+    }, [currentIndex, pages, generateAndLoadAudio, playLoadedAudio, story.storyId, updatePageImage, isEndPage, isFocused]);
+
+    // Stop narration as soon as this reader loses focus, so an instance left
+    // mounted on an inactive tab can't keep playing over the focused reader.
+    useEffect(() => {
+        if (!isFocused && playerRef.current) {
+            void stopPlayback();
+        }
+    }, [isFocused, stopPlayback]);
 
     // Track story_opened once on mount
     useEffect(() => {

--- a/components/__tests__/BookReader-test.tsx
+++ b/components/__tests__/BookReader-test.tsx
@@ -21,6 +21,13 @@ import audioCache from '@/services/narration/audioCache';
 // narration player is driven a bounded number of times per page.
 // ---------------------------------------------------------------------------
 
+// Control screen focus: BookReader only narrates when its screen is focused, so
+// a second instance left mounted on an inactive tab stays silent.
+let mockIsFocused = true;
+jest.mock('@react-navigation/native', () => ({
+    useIsFocused: () => mockIsFocused,
+}));
+
 // Replace the narration player with controllable jest.fns (the global mock in
 // jest.setup.js lacks pause/cleanup, which BookReader calls).
 jest.mock('@/services/narration', () => ({
@@ -92,6 +99,7 @@ describe('BookReader – auto-play behavior (card #39)', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         audioCache.clear();
+        mockIsFocused = true;
         seedStory();
         resetNarration();
     });
@@ -157,6 +165,18 @@ describe('BookReader – auto-play behavior (card #39)', () => {
         });
 
         expect(generateSpeechMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not narrate when its screen is not focused (no duplicate audio from an off-screen reader)', async () => {
+        // Reproduces the two-tracks bug: opening a book populates the global
+        // story, which also mounts a second BookReader on the inactive Lab tab.
+        // That off-screen (unfocused) instance must stay silent.
+        mockIsFocused = false;
+        render(<BookReader onBack={jest.fn()} />);
+
+        await new Promise(resolve => setTimeout(resolve, 50));
+        expect(generateSpeechMock).not.toHaveBeenCalled();
+        expect(createNarrationPlayerMock).not.toHaveBeenCalled();
     });
 
     it('does not narrate until Play is pressed when auto-play is disabled', async () => {


### PR DESCRIPTION
## Summary
Opening a book from the bookshelf started **two simultaneous narration tracks**, and pressing Pause only stopped one.

**Root cause:** the bookshelf detail screen (`app/(tabs)/bookshelf/[slug].tsx`) writes the opened story into the global `storyStore`, including `story.content`. `StoryScreen` (the "Lab" tab) renders its own `<BookReader/>` whenever `story.content` is set — and inactive tabs stay mounted (see the note in `app/(tabs)/_layout.tsx`). So a second `BookReader` mounts on the Lab tab, reads the same global story + narration state, and also auto-plays. Each instance owns its own `NarrationPlayer`, so the visible reader's Pause only stops its own player while the off-screen one keeps going.

**Fix:** gate auto-play on `useIsFocused()` and stop playback when a reader loses focus, so only the on-screen reader narrates — regardless of how many instances are mounted. This also stops narration when switching tabs mid-read.

Follow-up to #21 (the auto-play infinite-loop fix); same component.

## Test plan
- [x] `npx jest components/__tests__/BookReader-test.tsx` — 5 tests pass, including a new case: an unfocused reader generates no audio and never creates a player.
- [x] `npx tsc --noEmit` and `npx eslint` clean on changed files.
- [ ] Manual: with a generated story open on the Lab tab, switch to Bookshelf and open a saved book — confirm only one narration plays and Pause silences it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)