### PR TITLE
chore(deps): update posthog-react-native to 4.53.0 (card #40)

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,5 @@
 // metro.config.js
+const path = require('path');
 const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
@@ -15,5 +16,32 @@ config.resolver.extraNodeModules = {
 // `true`, but that flip can't be validated for native here, so leave it pinned.
 config.resolver.unstable_enablePackageExports = false;
 config.resolver.unstable_conditionNames = ['react-native', 'browser', 'require'];
+
+// posthog-react-native (>= 4.38) imports `@posthog/core/surveys`, a package.json
+// `exports` subpath. With `unstable_enablePackageExports` pinned `false` above,
+// Metro can't map that subpath to its real location on disk, so the bundle fails
+// to resolve it. Alias just this one subpath to its CJS entry instead of flipping
+// the global package-exports flag (which the comment above keeps off for native).
+// `@posthog/core`'s `exports` map only exposes `./surveys` (and not `.` deep
+// paths or `./package.json`), so derive the package root from its resolvable
+// main entry and join the on-disk CJS path manually.
+const posthogCoreMarker = path.join('@posthog', 'core');
+const posthogCoreMain = require.resolve('@posthog/core');
+const posthogCoreRoot = posthogCoreMain.slice(
+  0,
+  posthogCoreMain.indexOf(posthogCoreMarker) + posthogCoreMarker.length,
+);
+const posthogSurveys = path.join(posthogCoreRoot, 'dist/surveys/index.js');
+const defaultResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === '@posthog/core/surveys') {
+    return { type: 'sourceFile', filePath: posthogSurveys };
+  }
+  return (defaultResolveRequest ?? context.resolveRequest)(
+    context,
+    moduleName,
+    platform,
+  );
+};
 
 module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "expo-status-bar": "~55.0.6",
         "expo-system-ui": "~55.0.19",
         "expo-web-browser": "~55.0.17",
-        "posthog-react-native": "~4.37.3",
+        "posthog-react-native": "~4.53.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.6",
@@ -2029,31 +2029,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3535,13 +3510,19 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
-      "integrity": "sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.0.tgz",
+      "integrity": "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==",
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.6"
+        "@posthog/types": "^1.391.1"
       }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.391.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.1.tgz",
+      "integrity": "sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.4",
@@ -7878,6 +7859,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13816,21 +13798,23 @@
       "license": "MIT"
     },
     "node_modules/posthog-react-native": {
-      "version": "4.37.6",
-      "resolved": "https://registry.npmjs.org/posthog-react-native/-/posthog-react-native-4.37.6.tgz",
-      "integrity": "sha512-LoZTcSYPebr125QFdTySwLyZT/LVU8xmkRAYPCwS18IqLpXY6hsbgjeIyQhi9RpEKIbdvUR6sNuCKx/EaKnqNg==",
+      "version": "4.53.0",
+      "resolved": "https://registry.npmjs.org/posthog-react-native/-/posthog-react-native-4.53.0.tgz",
+      "integrity": "sha512-N7hfRpT1gWW7aT5XivD/+Xxf3X43HvHEEzK1mow0QSshki2elpi7nzcBzGOLRKFqIBlFEmvOh25X0vQeKbUXYQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "1.24.1"
+        "@posthog/core": "^1.38.0",
+        "@posthog/types": "^1.391.1"
       },
       "peerDependencies": {
+        "@posthog/react-native-plugin": ">= 2.1.1",
         "@react-native-async-storage/async-storage": ">=1.0.0",
         "@react-navigation/native": ">= 5.0.0",
         "expo-application": ">= 4.0.0",
         "expo-device": ">= 4.0.0",
         "expo-file-system": ">= 13.0.0",
         "expo-localization": ">= 11.0.0",
-        "posthog-react-native-session-replay": ">= 1.5.0",
+        "posthog-react-native-session-replay": ">= 1.6.0",
         "react-native-device-info": ">= 10.0.0",
         "react-native-localize": ">= 3.0.0",
         "react-native-navigation": ">= 6.0.0",
@@ -13838,6 +13822,9 @@
         "react-native-svg": ">= 15.0.0"
       },
       "peerDependenciesMeta": {
+        "@posthog/react-native-plugin": {
+          "optional": true
+        },
         "@react-native-async-storage/async-storage": {
           "optional": true
         },
@@ -13869,6 +13856,9 @@
           "optional": true
         },
         "react-native-safe-area-context": {
+          "optional": true
+        },
+        "react-native-svg": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "expo-status-bar": "~55.0.6",
     "expo-system-ui": "~55.0.19",
     "expo-web-browser": "~55.0.17",
-    "posthog-react-native": "~4.37.3",
+    "posthog-react-native": "~4.53.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.6",


### PR DESCRIPTION
## Summary
Bumps `posthog-react-native` from `~4.37.3` to `~4.53.0` (Fizzy card #40) and regenerates the lockfile.

- All releases between 4.37 and 4.53 are minor/patch within v4 — no major bump. The analytics API we use (`PostHog` constructor, `PostHogProvider`, `usePostHog`, `capture/identify/reset`) is unchanged.
- **Gotcha:** 4.53 ships a new **surveys** feature whose code does `import "@posthog/core/surveys"` — a `package.json` `exports` subpath. Our `metro.config.js` deliberately pins `unstable_enablePackageExports = false` (native-safety), so Metro couldn't resolve the subpath and the **web bundle failed**.
- Instead of flipping that global flag (which the existing comment says can't be validated for native here), this adds a **targeted `resolveRequest`** that aliases only `@posthog/core/surveys` to its on-disk CJS entry. Everything else still delegates to the default resolver, so it's platform-agnostic.

## Test plan
- [x] `npm run type-check` — clean
- [x] `npm test` — 32/32 pass
- [x] `npm run build:web` — bundles successfully
- [x] `npx expo export --platform ios` — native Metro bundle builds successfully
- [ ] Runtime analytics capture (event/session tracking) — can't be exercised locally; the PostHog client only initializes when `appEnv === 'production'` with a real key. Needs a staging deploy to verify live capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)