### PR TITLE
chore(ci): move frontend deploy actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -27,7 +27,6 @@ permissions:
 env:
   NODE_VERSION: '24'
   AWS_REGION: us-east-1
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # Determine environment based on branch or manual input
@@ -63,16 +62,16 @@ jobs:
       cloudfront_domain: ${{ steps.terraform.outputs.cloudfront_domain_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
           
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~1.0"
           terraform_wrapper: false
@@ -206,7 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -241,7 +240,7 @@ jobs:
     environment: ${{ needs.setup.outputs.environment }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -335,7 +334,7 @@ jobs:
           path: dist/
           
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -447,7 +446,7 @@ jobs:
     environment: ${{ needs.setup.outputs.environment }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/rollback-frontend.yml
+++ b/.github/workflows/rollback-frontend.yml
@@ -21,7 +21,6 @@ permissions:
 
 env:
   AWS_REGION: us-east-1
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   rollback:
@@ -44,7 +43,7 @@ jobs:
           fi
           
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
Node 20 is deprecated on GitHub Actions runners. The frontend deploy/rollback workflows had three actions still pinned to Node 20 majors (surfaced in the deprecation warning): `actions/checkout@v4`, `aws-actions/configure-aws-credentials@v4`, and `hashicorp/setup-terraform@v3`, forced onto Node 24 via a `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env workaround.

This bumps those three to their current Node 24-native majors and drops the workaround:
- `actions/checkout@v4` → `@v5`
- `aws-actions/configure-aws-credentials@v4` → `@v6`
- `hashicorp/setup-terraform@v3` → `@v4`
- removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from both `deploy-frontend.yml` and `rollback-frontend.yml` (now dead config)

`NODE_VERSION: '24'` is kept. The remaining `actions/*@v4` (setup-node, cache, upload-artifact, download-artifact) already run on Node 24 and were not flagged by the deprecation warning, so they're left as-is.

## Input compatibility
Verified our `with:` blocks still match each new major (no breaking input changes for what we use):
- checkout: used bare, no inputs
- configure-aws-credentials: `role-to-assume`, `aws-region` unchanged (v5's only input breaking change was invalid-boolean handling, which we don't use)
- setup-terraform: `terraform_version`, `terraform_wrapper` unchanged (v4's only breaking change is the Node 24 runtime)

## Test plan
- [x] YAML parses (`yaml.safe_load` on both workflows)
- [x] `npm test` green (32 passed)
- [x] `npm run lint` exit 0 (tsc + expo lint)
- [ ] Full workflow can only be exercised on a real push/dispatch to AWS — verified by reading each action's release notes rather than running end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)