### PR TITLE
fix(ci): sharpen PR review bot quality after grading its first runs

### DIFF
--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -11,6 +11,10 @@ Your job:
 
 Review standards:
 1. Correctness: Does the change do what it claims? Are there bugs, regressions, or missing cases?
+   When the diff makes multiple sequential calls with side effects (API calls, writes, state
+   changes), trace what actually happens end to end — don't just check each call in isolation.
+   A common bug class here is a step silently happening twice, happening out of order, or a
+   later step invalidating an earlier one's effect.
 2. Security: Any injection, auth, secrets, access control, or unsafe deserialization risks?
 3. Tests: Are tests present, meaningful, and aligned with the change?
 4. Maintainability: Is the code readable, consistent, and easy to change later?
@@ -23,11 +27,17 @@ Decision rules:
 - COMMENT if the PR is broadly acceptable but has non-blocking improvements or questions.
 - APPROVE if the PR is sound and no blocking issues remain.
 
+Every note or comment (blocking or not) must name something concrete in this diff — a file,
+behavior, or scenario. Do not emit generic advice that could be pasted onto any PR unchanged
+(e.g. "add more tests", "improve error handling", "add a timeout/retry") unless you also say
+exactly which case is untested or which call lacks handling and what failure that allows.
+If you have no diff-specific note to make for a standard, skip it.
+
 Output must be valid JSON only, with this shape:
 
 {
   "decision": "approve" | "comment" | "request_changes",
-  "summary_comment": "A full PR summary comment, including the final decision tree and rationale.",
+  "summary_comment": "2-4 sentences: what this PR does, the decision, and the specific reasoning for it.",
   "inline_comments": [
     {
       "path": "relative/file/path",
@@ -35,11 +45,6 @@ Output must be valid JSON only, with this shape:
       "side": "RIGHT",
       "body": "Inline review comment or question"
     }
-  ],
-  "decision_tree": [
-    "Approve if ...",
-    "Comment if ...",
-    "Request changes if ..."
   ],
   "blocking_issues": [
     "..."

--- a/scripts/pr-review.mjs
+++ b/scripts/pr-review.mjs
@@ -121,7 +121,7 @@ const decision = normalizeDecision(review.decision);
 const reviewEvent = decision === "request_changes" ? "REQUEST_CHANGES" : "COMMENT";
 
 // Build the review body (summary + notes).
-let body = review.summary_comment || "AI review completed.";
+let body = `### 🤖 PR Review Bot\n\n${review.summary_comment || "AI review completed."}`;
 
 if (review.blocking_issues?.length) {
   body += "\n## Blocking issues\n";
@@ -132,6 +132,10 @@ if (review.non_blocking_notes?.length) {
   body += "\n## Non-blocking notes\n";
   for (const item of review.non_blocking_notes) body += `- ${item}\n`;
 }
+
+// Record which provider/model produced this review — makes it possible to compare review
+// quality across model swaps later without cross-referencing repo variable history.
+body += `\n\n<sub>Reviewed by \`${provider}/${model}\`</sub>`;
 
 // Attach inline comments to the SINGLE review (posting them individually would create a
 // second, empty-bodied review). The reviews endpoint takes a `comments` array.

--- a/scripts/pr-review.mjs
+++ b/scripts/pr-review.mjs
@@ -65,9 +65,22 @@ const [prData, files] = await Promise.all([
 
 const skill = await fs.readFile(".github/skills/pr-review.md", "utf8");
 
+// Lockfiles are machine-generated and can dwarf the actual code change (a bump of one
+// package can rewrite hundreds of lines of peer/libc metadata). Sending the full patch
+// wastes context and dilutes model attention on the files that matter, so summarize instead.
+const LOCKFILE_NAMES = new Set([
+  "package-lock.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "composer.lock",
+]);
+
 const diffText = files
   .map((f) => {
-    const patch = f.patch ?? "(no patch available: binary file or too large)";
+    const isLockfile = LOCKFILE_NAMES.has(f.filename.split("/").pop());
+    const patch = isLockfile
+      ? "(lockfile: patch omitted from review — dependency version bumps only)"
+      : f.patch ?? "(no patch available: binary file or too large)";
     return `FILE: ${f.filename}
 STATUS: ${f.status}
 CHANGES: +${f.additions} -${f.deletions}
@@ -109,8 +122,6 @@ const reviewEvent = decision === "request_changes" ? "REQUEST_CHANGES" : "COMMEN
 
 // Build the review body (summary + notes).
 let body = review.summary_comment || "AI review completed.";
-body += "\n\n## Decision tree\n";
-for (const item of review.decision_tree || []) body += `- ${item}\n`;
 
 if (review.blocking_issues?.length) {
   body += "\n## Blocking issues\n";


### PR DESCRIPTION
## Summary
Graded the bot's first two reviews (PRs #30, #31) and found real quality gaps:
- It missed the double-review bug in #30 entirely — the exact bug #31 had to come back and fix — despite that being a straightforward control-flow trace.
- Both reviews padded their comments with generic, copy-paste-able advice ("add more tests", "improve error handling", "add a timeout/retry").
- Every review rendered a `## Decision tree` section that was just the skill file's own rubric ("Approve if...", "Comment if...") echoed back verbatim — no PR-specific value, pure noise.

Changes:
- Drop the `decision_tree` output field and its rendering; `summary_comment` now must carry the specific rationale directly instead of duplicating the rubric.
- Skill file now requires every blocking/non-blocking note to name something concrete in the diff — generic advice without a specific case/behavior is banned.
- Added explicit guidance to trace side effects across sequential API calls end-to-end, targeting the bug class the bot missed in #30.
- Lockfile patches (package-lock.json, yarn.lock, pnpm-lock.yaml, composer.lock) are now omitted from what's sent to the model — PR #30's diff was ~50% lockfile noise, which likely diluted the model's attention on the actual code.

Not changed here (flagging for a separate decision): the bot currently runs on `meta-llama/Llama-3.3-70B-Instruct-Turbo` via Together, which is the likely root cause of the shallow, generic feedback. Worth evaluating a stronger model (Anthropic/OpenAI options are already wired into the script) against the cost tradeoff.

## Test plan
- [ ] Open a small test PR against this branch's target and confirm the bot's review body no longer contains a "## Decision tree" section
- [ ] Confirm a PR touching package-lock.json shows the lockfile omitted-patch placeholder rather than the full diff
- [ ] Confirm non-blocking notes reference specific diff content rather than generic advice