### PR TITLE
fix(story): separate saved-story reading from in-progress creation

### DIFF
--- a/app/(tabs)/bookshelf/[slug].tsx
+++ b/app/(tabs)/bookshelf/[slug].tsx
@@ -1,17 +1,20 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import client from '@/src/api/client';
 import BookReader from '@/components/BookReader/BookReader';
 import { parseStoryBody } from '@/src/utils/parseStoryBody';
 import { StorySection } from '@/types/story';
-import { useStoryStore } from '@/src/stores/storyStore';
 
 export default function StoryDetailScreen() {
     const { slug } = useLocalSearchParams<{ slug: string }>();
     const router = useRouter();
+    // Local to this screen — a saved/bookshelf story never touches the shared
+    // storyStore slice used by the in-progress creation flow, so opening one
+    // can't clobber a story the user is still creating (card #47).
     const [sections, setSections] = useState<StorySection[]>([]);
-    const [isLegacy, setIsLegacy] = useState(false);
+    const [storyId, setStoryId] = useState<number | null>(null);
+    const [storyName, setStoryName] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -29,22 +32,14 @@ export default function StoryDetailScreen() {
                         illustrationPrompt: p.illustrationPrompt ?? null,
                     }));
                     setSections(mappedSections);
-
-                    // Set story data in story store for lazy image loading
-                    useStoryStore.setState({
-                        story: {
-                            content: story.body || null,
-                            sections: mappedSections,
-                            storyId: story.id,
-                            name: story.title || story.name || null,
-                        },
-                    });
                 } else {
                     // Legacy: parse from body
                     const { sections: parsed } = parseStoryBody(story.body);
                     setSections(parsed);
-                    setIsLegacy(true);
                 }
+
+                setStoryId(story.id ?? null);
+                setStoryName(story.title || story.name || null);
             } catch {
                 setError('Could not load this story.');
             } finally {
@@ -56,6 +51,15 @@ export default function StoryDetailScreen() {
             void fetchStory();
         }
     }, [slug]);
+
+    const handleUpdatePageImage = useCallback((pageIndex: number, imageUrl: string) => {
+        setSections(prev => {
+            if (pageIndex < 0 || pageIndex >= prev.length) return prev;
+            const next = [...prev];
+            next[pageIndex] = { ...next[pageIndex], imageUrl };
+            return next;
+        });
+    }, []);
 
     if (loading) {
         return (
@@ -78,7 +82,13 @@ export default function StoryDetailScreen() {
 
     return (
         <View style={styles.fullScreen}>
-            <BookReader sections={isLegacy ? sections : undefined} onBack={() => router.push('/bookshelf')} />
+            <BookReader
+                sections={sections}
+                name={storyName ?? undefined}
+                storyId={storyId}
+                onBack={() => router.push('/bookshelf')}
+                onUpdatePageImage={handleUpdatePageImage}
+            />
         </View>
     );
 }

--- a/components/BookReader/BookReader.tsx
+++ b/components/BookReader/BookReader.tsx
@@ -29,7 +29,12 @@ import storyGenerationService from '@/services/storyGenerationService';
 interface BookReaderProps {
     sections?: StorySection[];
     name?: string;
+    storyId?: number | null;
     onBack?: () => void;
+    // When reading from props (e.g. the bookshelf reader), lazily-generated
+    // page images are reported back through this callback instead of writing
+    // into the shared storyStore slice — see card #47.
+    onUpdatePageImage?: (pageIndex: number, imageUrl: string) => void;
 }
 
 const ShimmerPlaceholder = () => {
@@ -65,9 +70,9 @@ const ShimmerPlaceholder = () => {
     );
 };
 
-const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = {}) => {
+const BookReader = ({ sections: sectionsProp, name, storyId: storyIdProp, onBack, onUpdatePageImage }: BookReaderProps = {}) => {
     const story = useStoryStore(s => s.story);
-    const updatePageImage = useStoryStore(s => s.updatePageImage);
+    const updatePageImageStore = useStoryStore(s => s.updatePageImage);
     const resetConversation = useConversationStore(s => s.resetConversation);
     const resetStory = useStoryStore(s => s.resetStory);
     const resetNarration = useNarrationStore(s => s.resetNarration);
@@ -90,11 +95,23 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         [sectionsProp, story.sections]
     );
 
+    // When driven by props (bookshelf reader), the story id and page-image
+    // updates come from/go back to the caller's own local state, not the
+    // shared storyStore slice used by the in-progress creation flow.
+    const effectiveStoryId = sectionsProp ? (storyIdProp ?? null) : story.storyId;
+    const handlePageImageUpdate = useCallback((pageIndex: number, imageUrl: string) => {
+        if (onUpdatePageImage) {
+            onUpdatePageImage(pageIndex, imageUrl);
+        } else {
+            updatePageImageStore(pageIndex, imageUrl);
+        }
+    }, [onUpdatePageImage, updatePageImageStore]);
+
     // Whether this reader is on the currently-focused screen. A BookReader can
-    // stay mounted on an inactive tab — e.g. the Lab tab still holds the
-    // generated story (StoryScreen renders it whenever story.content is set,
-    // which opening a bookshelf book also populates). Only the focused reader is
-    // allowed to narrate, otherwise two instances auto-play at once.
+    // stay mounted on an inactive tab — e.g. the Lab tab still holds an
+    // in-progress creation's story.content and renders its own BookReader
+    // whenever that's set. Only the focused reader is allowed to narrate,
+    // otherwise two instances auto-play at once.
     const isFocused = useIsFocused();
 
     const [currentIndex, setCurrentIndex] = useState(0);
@@ -518,20 +535,19 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         }
 
         // Lazy image fetching: if page has illustrationPrompt but no imageUrl, generate on demand
-        const storyId = story.storyId;
         if (
             currentPage &&
             currentPage.illustrationPrompt &&
             !currentPage.imageUrl &&
-            storyId
+            effectiveStoryId
         ) {
             setIsLoadingImage(true);
             const pageNumber = currentIndex + 1; // API uses 1-based page numbers
-            storyGenerationService.generatePageImage(storyId, pageNumber)
+            storyGenerationService.generatePageImage(effectiveStoryId, pageNumber)
                 .then((url) => {
                     if (cancelled) return;
                     if (url) {
-                        updatePageImage(currentIndex, url);
+                        handlePageImageUpdate(currentIndex, url);
                     }
                     setIsLoadingImage(false);
                 })
@@ -544,7 +560,7 @@ const BookReader = ({ sections: sectionsProp, name, onBack }: BookReaderProps = 
         return () => {
             cancelled = true;
         };
-    }, [currentIndex, pages, generateAndLoadAudio, playLoadedAudio, story.storyId, updatePageImage, isEndPage, isFocused]);
+    }, [currentIndex, pages, generateAndLoadAudio, playLoadedAudio, effectiveStoryId, handlePageImageUpdate, isEndPage, isFocused]);
 
     // Stop narration as soon as this reader loses focus, so an instance left
     // mounted on an inactive tab can't keep playing over the focused reader.

--- a/components/__tests__/BookReader-test.tsx
+++ b/components/__tests__/BookReader-test.tsx
@@ -7,6 +7,7 @@ import { useNarrationStore } from '@/src/stores/narrationStore';
 import { createNarrationPlayer } from '@/services/narration';
 import elevenLabsService from '@/services/elevenLabsService';
 import audioCache from '@/services/narration/audioCache';
+import storyGenerationService from '@/services/storyGenerationService';
 
 // ---------------------------------------------------------------------------
 // Component tests for BookReader auto-play wiring (Fizzy card #39).
@@ -197,5 +198,67 @@ describe('BookReader – auto-play behavior (card #39)', () => {
             expect(currentPlayer().play).toHaveBeenCalledTimes(1);
         });
         expect(useNarrationStore.getState().isAutoPlayEnabled).toBe(true);
+    });
+});
+
+describe('BookReader – bookshelf reader does not share the creation story slice (card #47)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        audioCache.clear();
+        mockIsFocused = true;
+        seedStory();
+        resetNarration();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('props-driven mode: lazy-loads a page image via the given storyId and reports it back through onUpdatePageImage instead of the shared store', async () => {
+        const propsSections = [
+            { text: 'Once upon a time...', imageUrl: null, illustrationPrompt: 'a fox in the woods' },
+        ];
+        const onUpdatePageImage = jest.fn();
+        const generatePageImageMock = storyGenerationService.generatePageImage as jest.Mock;
+        generatePageImageMock.mockResolvedValueOnce('https://example.com/fox.png');
+
+        const storySliceBefore = useStoryStore.getState().story;
+
+        render(
+            <BookReader
+                sections={propsSections}
+                storyId={42}
+                onBack={jest.fn()}
+                onUpdatePageImage={onUpdatePageImage}
+            />
+        );
+
+        await waitFor(() => {
+            expect(onUpdatePageImage).toHaveBeenCalledWith(0, 'https://example.com/fox.png');
+        });
+
+        expect(generatePageImageMock).toHaveBeenCalledWith(42, 1);
+        // The shared creation-flow story slice must be untouched by a bookshelf read.
+        expect(useStoryStore.getState().story).toBe(storySliceBefore);
+    });
+
+    it('store-driven mode (no props): still lazy-loads via the shared story slice when no onUpdatePageImage is given', async () => {
+        useStoryStore.setState({
+            story: {
+                content: null,
+                sections: [{ text: 'Once upon a time...', imageUrl: null, illustrationPrompt: 'a fox in the woods' }],
+                storyId: 7,
+                name: 'The Brave Fox',
+            },
+        });
+        const generatePageImageMock = storyGenerationService.generatePageImage as jest.Mock;
+        generatePageImageMock.mockResolvedValueOnce('https://example.com/fox.png');
+
+        render(<BookReader onBack={jest.fn()} />);
+
+        await waitFor(() => {
+            expect(useStoryStore.getState().story.sections[0].imageUrl).toBe('https://example.com/fox.png');
+        });
+        expect(generatePageImageMock).toHaveBeenCalledWith(7, 1);
     });
 });

--- a/pages/StoryScreen/StoryScreen.tsx
+++ b/pages/StoryScreen/StoryScreen.tsx
@@ -32,10 +32,11 @@ const StoryScreen = () => {
   };
 
   // Show story content (without background). Gate the reader on isFocused so an
-  // unfocused Lab tab doesn't mount an off-screen BookReader — that mount fires a
-  // STORY_OPENED analytics event and kicks off lazy page-image generation for a
-  // reader nobody is looking at (e.g. when a bookshelf book is opened on another
-  // tab). See card #42.
+  // unfocused Lab tab doesn't mount an off-screen BookReader for the in-progress
+  // creation's story — that mount fires a STORY_OPENED analytics event and kicks
+  // off lazy page-image generation for a reader nobody is looking at (e.g. while
+  // browsing another tab). See card #42; the bookshelf reader (card #47) has its
+  // own local state and no longer shares this store slice at all.
   if (story.content) {
     return (
       <Layout>


### PR DESCRIPTION
## Summary
- The bookshelf reader (`app/(tabs)/bookshelf/[slug].tsx`) wrote a fetched saved story directly into the shared `storyStore` `story` slice — the same slice the in-progress creation flow (Lab tab) uses — so opening a saved book could clobber a story the user was still creating, and the two readers fought over one slice.
- The bookshelf detail screen now keeps `sections`/`storyId`/`name` as local component state instead of touching `useStoryStore` at all.
- `BookReader` gains a `storyId` prop and an `onUpdatePageImage` callback: when driven by props (bookshelf mode) lazy page-image generation reads/writes through those props; when not (the in-progress creation reader via `StoryContent`), it falls back to the shared store exactly as before.
- Updated stale comments in `BookReader.tsx` / `StoryScreen.tsx` that described the old (now-removed) store-clobbering behavior.

## Test plan
- [x] `npm test` — 37/37 passing, including two new BookReader tests: props-driven lazy image loading reports through `onUpdatePageImage` and leaves the shared story slice untouched; store-driven mode (no props) still works for the creation-flow reader.
- [x] `npm run lint` — `tsc --noEmit` + `expo lint` exit 0.

Fizzy #47.