### PR TITLE
chore(metro): enable unstable_enablePackageExports, drop posthog shim

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,4 @@
 // metro.config.js
-const path = require('path');
 const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
@@ -11,37 +10,13 @@ config.resolver.extraNodeModules = {
 };
 
 // Add resolver configuration for ES modules compatibility.
-// Kept at `false` deliberately: this is a global resolver setting that also
-// affects native bundles. The SDK 54 web build succeeds with it flipped to
-// `true`, but that flip can't be validated for native here, so leave it pinned.
-config.resolver.unstable_enablePackageExports = false;
+// Enabled per the Fizzy #43 audit (see PLAN.md `## Notes`): bundling every
+// platform with this flag on vs. off showed no graph-shape changes and no
+// unresolved imports, just same-package format swaps (UMD/CJS -> ESM/modern
+// builds) plus native resolution of package.json `exports` subpaths such as
+// `@posthog/core/surveys`, which previously needed the manual resolveRequest
+// alias below.
+config.resolver.unstable_enablePackageExports = true;
 config.resolver.unstable_conditionNames = ['react-native', 'browser', 'require'];
-
-// posthog-react-native (>= 4.38) imports `@posthog/core/surveys`, a package.json
-// `exports` subpath. With `unstable_enablePackageExports` pinned `false` above,
-// Metro can't map that subpath to its real location on disk, so the bundle fails
-// to resolve it. Alias just this one subpath to its CJS entry instead of flipping
-// the global package-exports flag (which the comment above keeps off for native).
-// `@posthog/core`'s `exports` map only exposes `./surveys` (and not `.` deep
-// paths or `./package.json`), so derive the package root from its resolvable
-// main entry and join the on-disk CJS path manually.
-const posthogCoreMarker = path.join('@posthog', 'core');
-const posthogCoreMain = require.resolve('@posthog/core');
-const posthogCoreRoot = posthogCoreMain.slice(
-  0,
-  posthogCoreMain.indexOf(posthogCoreMarker) + posthogCoreMarker.length,
-);
-const posthogSurveys = path.join(posthogCoreRoot, 'dist/surveys/index.js');
-const defaultResolveRequest = config.resolver.resolveRequest;
-config.resolver.resolveRequest = (context, moduleName, platform) => {
-  if (moduleName === '@posthog/core/surveys') {
-    return { type: 'sourceFile', filePath: posthogSurveys };
-  }
-  return (defaultResolveRequest ?? context.resolveRequest)(
-    context,
-    moduleName,
-    platform,
-  );
-};
 
 module.exports = config;


### PR DESCRIPTION
## Summary
- Flips `config.resolver.unstable_enablePackageExports` to `true` in `frontend/metro.config.js`, per the Fizzy #43 step-1 audit (see `PLAN.md`), which found no graph-shape changes or unresolved imports on iOS/Android/web under the flag — just same-package format swaps (UMD/CJS → ESM/modern builds).
- Deletes the now-unneeded `@posthog/core/surveys` `resolveRequest` alias (and the `path` import it needed): Metro now resolves that package's `exports` subpath natively.
- Leaves `unstable_conditionNames` (`['react-native', 'browser', 'require']`) unchanged — the audit found no package needing a different condition order.

Closes Fizzy card #43.

## Test plan
- [x] `npm test` — 37 passed
- [x] `npm run lint` — exit 0 (tsc --noEmit + expo lint)
- [x] `npx expo export --platform web` — bundles successfully (all 12 static routes)
- [ ] **Manual gate (not done in this session):** iOS/Android device/simulator smoke-test of the flag flip
- [ ] **Manual gate (not done in this session):** real-browser check of an authenticated API call (login or story-generation) on web — the audit found axios's resolved bundle artifact changes under the flag (prebuilt `dist/browser/axios.cjs` vs. unbundled ESM source), same file either way but worth an explicit confirmation. Attempted via Playwright in this sandbox but the container lacks Chromium's runtime deps (`libasound.so.2`) and has no sudo to install them.