### PR TITLE
chore(deps): upgrade @elevenlabs/client 0.3 -> 1.x, drop unused elevenlabs-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-polly": "^3.848.0",
         "@aws-sdk/client-transcribe-streaming": "^3.848.0",
-        "@elevenlabs/client": "^0.3.0",
-        "@elevenlabs/elevenlabs-js": "^2.5.0",
+        "@elevenlabs/client": "^1.14.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/slider": "5.1.2",
         "axios": "^1.13.2",
@@ -1924,27 +1923,20 @@
       }
     },
     "node_modules/@elevenlabs/client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-0.3.0.tgz",
-      "integrity": "sha512-xyNGNo3L6z4Sog44jpGWIIXgRskPolDhly7nQ+H62Ca2Q3s1CTkJ/xhDNk06eRr21aAzW8122FMOyTemg0t8kQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-1.14.0.tgz",
+      "integrity": "sha512-6p16krEwhRQpMidOhpcJk9o7cu3hihnAHenlLxQj9DMa+LPLx/IILsOArNDZpq0DOXrfQ72njludoTl1dlUkCQ==",
       "license": "MIT",
       "dependencies": {
-        "livekit-client": "^2.11.4"
+        "@elevenlabs/types": "0.16.0",
+        "livekit-client": "2.16.1"
       }
     },
-    "node_modules/@elevenlabs/elevenlabs-js": {
-      "version": "2.56.0",
-      "resolved": "https://registry.npmjs.org/@elevenlabs/elevenlabs-js/-/elevenlabs-js-2.56.0.tgz",
-      "integrity": "sha512-cB96D/MZugHpT/Gs59VFDqWX683XTnDfj3WwMcy8KulTSXkdPbBEOqlKYC/p6zXmCbUu8zXIsCaeQ3VPNIwC8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "command-exists": "^1.2.9",
-        "node-fetch": "^2.7.0",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
+    "node_modules/@elevenlabs/types": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.16.0.tgz",
+      "integrity": "sha512-3afZEP+SxbD1CYbZtX6+7G0VPGfcR/z3XUNBeiXOm9/goOSFiJ2LRP9B8TMWLamZ1QpWT3UM6O82S/TUaF9f0w==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -3421,9 +3413,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@livekit/protocol": {
-      "version": "1.46.6",
-      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.46.6.tgz",
-      "integrity": "sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg==",
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.2.tgz",
+      "integrity": "sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
@@ -6587,12 +6579,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/command-exists": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -11942,20 +11928,21 @@
       "license": "MIT"
     },
     "node_modules/livekit-client": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.20.0.tgz",
-      "integrity": "sha512-RIJcpvBmOmwz3jTj3rmdY6Dzr55HrhcaJjMgY+HSmoEM+yIRyA40m7r8UKv0hnZWM3z/AYhP1q8C8ciz5UWFKQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.16.1.tgz",
+      "integrity": "sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@livekit/mutex": "1.1.1",
-        "@livekit/protocol": "1.46.6",
+        "@livekit/protocol": "1.42.2",
         "events": "^3.3.0",
         "jose": "^6.1.0",
         "loglevel": "^1.9.2",
         "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
         "tslib": "2.8.1",
         "typed-emitter": "^2.1.0",
-        "webrtc-adapter": "9.0.5"
+        "webrtc-adapter": "^9.0.1"
       },
       "peerDependencies": {
         "@types/dom-mediacapture-record": "^1"
@@ -16071,6 +16058,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -16627,9 +16620,9 @@
       }
     },
     "node_modules/webrtc-adapter": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
-      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "sdp": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@aws-sdk/client-polly": "^3.848.0",
     "@aws-sdk/client-transcribe-streaming": "^3.848.0",
-    "@elevenlabs/client": "^0.3.0",
-    "@elevenlabs/elevenlabs-js": "^2.5.0",
+    "@elevenlabs/client": "^1.14.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/slider": "5.1.2",
     "axios": "^1.13.2",
@@ -93,7 +92,7 @@
       "<rootDir>/jest.setup.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|zustand)"
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|zustand|@elevenlabs/.*)"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",


### PR DESCRIPTION
## Summary
- Bump `@elevenlabs/client` from `^0.3.0` to `^1.14.0` (Fizzy #44). The 1.x rewrite (now split into `TextConversation`/`VoiceConversation` under a `Conversation` namespace/type) keeps the same `Conversation.startSession()` call shape and callback payloads (`onConnect`, `onDisconnect`, `onMessage`, `onError`, `onStatusChange`, `onModeChange`) that `services/elevenLabsService.ts` and `src/hooks/useConversation.ts` already rely on, so no call-site changes were needed.
- The 1.x package ships ESM-only (no CJS build), which broke Jest's automock of `elevenLabsService` (`useConversation.test.ts`) with a `Cannot use import statement outside a module` error. Added `@elevenlabs/.*` to jest's `transformIgnorePatterns` exception list so Babel transforms it.
- Removed `@elevenlabs/elevenlabs-js` (the Node-oriented server SDK, `^2.5.0`). It has no imports anywhere in the frontend — the backend proxies all ElevenLabs API calls in PHP per `CLAUDE.md` — so it was unused dead weight rather than something to consolidate with.
- `package-lock.json` regenerated via `npm install` to stay in sync (verified with `npm ci`).

## Test plan
- [x] `npm test` — 35 passed (6 suites), including the previously-broken `useConversation.test.ts`
- [x] `npm run lint` (`tsc --noEmit && expo lint`) — exit 0
- [x] `npx expo export --platform web` — bundles successfully (3.4MB, 12 static routes)
- [ ] Manual smoke-test of a live conversation session (voice agent) on device/simulator — can't be exercised in this environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)