### PR TITLE
chore(deps): upgrade @react-native-async-storage/async-storage 2.2.0 -> 3.1.1

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -26,7 +26,7 @@ jest.mock('expo-router', () => ({
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () =>
-  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+  require('@react-native-async-storage/async-storage/jest')
 );
 
 // Mock expo modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-polly": "^3.848.0",
         "@aws-sdk/client-transcribe-streaming": "^3.848.0",
         "@elevenlabs/client": "^1.14.0",
-        "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-async-storage/async-storage": "3.1.1",
         "@react-native-community/slider": "5.1.2",
         "axios": "^1.13.2",
         "base64-js": "^1.5.1",
@@ -3880,15 +3880,16 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
-      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.1.1.tgz",
+      "integrity": "sha512-z+PnLz1n6ECKhgoHZHkfc+dijXZEyZnNFSajbtE0NEbsJhmX8x9GlOeiMQIKX2E4DUqPSgfIh4FYBv1M49KgPQ==",
       "license": "MIT",
       "dependencies": {
-        "merge-options": "^3.0.4"
+        "idb": "8.0.3"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-community/slider": {
@@ -9838,6 +9839,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10301,15 +10308,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -12171,18 +12169,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
-    },
-    "node_modules/merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@aws-sdk/client-polly": "^3.848.0",
     "@aws-sdk/client-transcribe-streaming": "^3.848.0",
     "@elevenlabs/client": "^1.14.0",
-    "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-async-storage/async-storage": "3.1.1",
     "@react-native-community/slider": "5.1.2",
     "axios": "^1.13.2",
     "base64-js": "^1.5.1",


### PR DESCRIPTION
## Summary
- Bumps `@react-native-async-storage/async-storage` from 2.2.0 to 3.1.1 (Fizzy card #45).
- v3's core API (`getItem`/`setItem`/`removeItem`/`getAllKeys`/`clear`) is unchanged and the default export still points to the v2 singleton storage, so no call-site changes were needed in `src/stores/storyStore.ts` or `src/stores/narrationStore.ts` — both only use `getItem`/`setItem`/`createJSONStorage` passthrough, and a repo-wide grep confirmed no `multiGet`/`multiSet`/`mergeItem`/`useAsyncStorage` usage anywhere (all removed/renamed in v3).
- Updated `jest.setup.js`: the jest mock subpath moved from `@react-native-async-storage/async-storage/jest/async-storage-mock` to `@react-native-async-storage/async-storage/jest` in v3.
- Auth tokens are stored via SecureStore/localStorage, not AsyncStorage, so they're unaffected by this bump.

**Note on the Expo SDK pin:** Expo 55's `bundledNativeModules.json` still lists `2.2.0` as the recommended version for this package, so `expo install --check` / `expo-doctor` will flag this as ahead of the SDK-pinned version. This is a deliberate, isolated major bump per the card, not an Expo-sanctioned one. v3's RN requirement is 0.76+; this project is on RN 0.83.6. v3.0.0's "extra Android install step" caveat (an Expo config plugin) was resolved in 3.1.0 — the native artifact is now published to Maven Central — so no `expo-with-async-storage` plugin is needed.

## Test plan
- [x] `npm test` — 35 passed
- [x] `npm run lint` (tsc --noEmit + expo lint) — exit 0
- [x] `npx expo export --platform web` — bundles cleanly
- [x] Manually exercised the new jest mock's `getItem`/`setItem`/`removeItem` round-trip via a standalone script
- [ ] **Remaining manual gate:** device/simulator smoke-test of saved-story persistence and auth flows — not exercisable in this environment (no RN native runtime here), flagging for human sign-off before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)