### PR TITLE
fix(ci): stop weak-model JSON drift from leaking [object Object] into reviews

### DIFF
--- a/.github/skills/pr-review.md
+++ b/.github/skills/pr-review.md
@@ -59,3 +59,6 @@ Inline comment guidance:
 - Use questions for uncertainty, e.g. “Could this ever be null here?”
 - Keep inline comments concise and actionable.
 - If you cannot confidently place a line-specific comment, put it in `non_blocking_notes` instead.
+- Do not leave a comment that only affirms or restates what the line does (e.g. "This correctly
+  handles X", "Good approach here"). An inline comment must flag a risk, bug, edge case, or a
+  genuine open question — if a line has none of those, don't comment on it at all.

--- a/scripts/pr-review.mjs
+++ b/scripts/pr-review.mjs
@@ -121,16 +121,16 @@ const decision = normalizeDecision(review.decision);
 const reviewEvent = decision === "request_changes" ? "REQUEST_CHANGES" : "COMMENT";
 
 // Build the review body (summary + notes).
-let body = `### 🤖 PR Review Bot\n\n${review.summary_comment || "AI review completed."}`;
+let body = `### 🤖 PR Review Bot\n\n${toText(review.summary_comment) || "AI review completed."}`;
 
 if (review.blocking_issues?.length) {
   body += "\n## Blocking issues\n";
-  for (const item of review.blocking_issues) body += `- ${item}\n`;
+  for (const item of review.blocking_issues) body += `- ${toText(item)}\n`;
 }
 
 if (review.non_blocking_notes?.length) {
   body += "\n## Non-blocking notes\n";
-  for (const item of review.non_blocking_notes) body += `- ${item}\n`;
+  for (const item of review.non_blocking_notes) body += `- ${toText(item)}\n`;
 }
 
 // Record which provider/model produced this review — makes it possible to compare review
@@ -141,8 +141,8 @@ body += `\n\n<sub>Reviewed by \`${provider}/${model}\`</sub>`;
 // second, empty-bodied review). The reviews endpoint takes a `comments` array.
 const inlineComments = Array.isArray(review.inline_comments) ? review.inline_comments : [];
 const comments = inlineComments
-  .filter((c) => c?.path && c?.line && c?.body)
-  .map((c) => ({ path: c.path, line: c.line, side: c.side || "RIGHT", body: c.body }));
+  .map((c) => ({ path: c?.path, line: Number(c?.line), side: c?.side || "RIGHT", body: toText(c?.body) }))
+  .filter((c) => c.path && Number.isFinite(c.line) && c.body);
 
 try {
   await github("POST", `/repos/${owner}/${repo}/pulls/${pull_number}/reviews`, {
@@ -166,6 +166,21 @@ try {
 }
 
 console.log(`Submitted review: ${reviewEvent}`);
+
+// Weaker models sometimes don't follow the requested JSON schema and wrap a note/comment
+// in an object (e.g. { note: "..." }) instead of returning a bare string. Left unguarded,
+// naive `${item}` interpolation prints the literal text "[object Object]" into the posted
+// GitHub review. Unwrap common field names, or fall back to JSON so nothing is silently lost.
+function toText(value) {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value === "object") {
+    const candidate = value.text ?? value.note ?? value.comment ?? value.body ?? value.message;
+    if (typeof candidate === "string") return candidate;
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
 
 function normalizeDecision(d) {
   const v = String(d || "").toLowerCase();


### PR DESCRIPTION
## Summary
- Graded the bot's actual reviews on PRs #33-#39 (currently running Together's `Qwen/Qwen2.5-7B-Instruct-Turbo`) and found it sometimes returns objects instead of bare strings for `blocking_issues`/`non_blocking_notes`/inline comment bodies. The script's naive `${item}` interpolation then posted the literal text `[object Object]` into real GitHub reviews on #36, #37, #38, #39.
- Adds a `toText()` helper that unwraps common object shapes (`text`/`note`/`comment`/`body`/`message`) or falls back to `JSON.stringify`, used everywhere a model-provided string is interpolated. Also hardens the inline-comment line filter to require a finite number instead of a bare truthy check.
- Skill update: bans praise-only inline comments (e.g. "this correctly handles X") — every real inline comment the bot left on #33/#35/#36/#37 was an affirmation, not a critique. Every comment must now flag a risk, bug, or open question.
- Companion eval-harness plan (not part of this PR, root-level doc, no code yet): `PR_REVIEW_EVAL.md`.

## Test plan
- [x] `node --check scripts/pr-review.mjs` passes
- [ ] Next PR against `main` gets reviewed with no `[object Object]` in the body
- [ ] Next PR with inline comments doesn't contain a pure-affirmation comment