### PR TITLE
ci(deploy): deploy staging from main, production from v* tags

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,8 +9,8 @@ This directory contains GitHub Actions workflows for deploying the StoryWriter f
 Main deployment workflow that handles both staging and production deployments.
 
 **Triggers:**
-- Push to `main` branch → Production deployment
-- Push to `develop` branch → Staging deployment  
+- Push of a `v*` tag → Production deployment
+- Push to `main` branch → Staging deployment
 - Manual trigger → Choose environment (staging/production)
 
 **Features:**
@@ -85,8 +85,8 @@ Both should point to their respective CloudFront distributions.
 ## Usage
 
 ### Automatic Deployments
-- Push to `develop` branch for staging deployment
-- Push to `main` branch for production deployment
+- Push to `main` branch for staging deployment
+- Push a `v*` tag (e.g. `v1.0.0`) for production deployment
 
 ### Manual Deployments
 1. Go to Actions tab in GitHub

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,7 +8,8 @@ name: Deploy Frontend
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
+    tags: [ 'v*' ]
   workflow_dispatch:
     inputs:
       environment:
@@ -23,6 +24,12 @@ on:
 permissions:
   id-token: write
   contents: read
+
+# One deploy at a time per environment: queued runs wait instead of racing a
+# deploy already in flight (never cancel a deploy mid-run).
+concurrency:
+  group: deploy-frontend-${{ github.event_name == 'workflow_dispatch' && inputs.environment || (startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging') }}
+  cancel-in-progress: false
 
 env:
   NODE_VERSION: '24'
@@ -41,7 +48,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             ENV="${{ github.event.inputs.environment }}"
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             ENV="production"
           else
             ENV="staging"


### PR DESCRIPTION
## Summary
Fizzy card #61 (release stream). Stops deploying production on every merge to main.

- `deploy-frontend.yml` push trigger now fires on `main` and `v*` tags; the dead `develop` branch trigger is removed.
- The setup job's ref→environment mapping changed: `refs/tags/v*` → **production**, `refs/heads/main` → **staging**. The `workflow_dispatch` environment input is unchanged.
- Added a workflow-level concurrency group keyed per environment (`deploy-frontend-production` / `deploy-frontend-staging`, derived from the ref or the dispatch input) with `cancel-in-progress: false`, so two quick merges queue instead of racing each other mid-deploy — and an in-flight deploy is never cancelled.
- Updated the trigger docs in `.github/workflows/README.md` to match. (The full release/hotfix/rollback process write-up in the frontend README is card #65's scope, not this PR.)

After this lands: merges to main deploy staging only; production deploys only from a semver `v*` tag (card #64 cuts `v1.0.0`). Note a tag push on a commit already on main produces two runs — a staging run for the branch push and a production run for the tag — which is the intended behavior.

## Test plan
- [x] YAML parses (`yaml.safe_load`)
- [x] `npm test` — 37/37 passing
- [x] `npm run lint` — exit 0
- [ ] After merge: verify a merge to main deploys staging only, and the first `v*` tag push targets production

🤖 Generated with [Claude Code](https://claude.com/claude-code)