### PR TITLE
chore(release): align app version to 1.0.0 with package.json as single source of truth

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,5 +1,9 @@
 require('dotenv').config();
 
+// Single source of truth for the app version: package.json, bumped via `npm version`,
+// which also creates the matching vX.Y.Z git tag.
+const { version } = require('./package.json');
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 const IS_STAGING = process.env.NODE_ENV === 'staging' || process.env.EXPO_ENV === 'staging';
 const IS_DEVELOPMENT = !IS_PRODUCTION && !IS_STAGING;
@@ -32,7 +36,7 @@ export default ({ config }) => ({
   expo: {
     name: IS_PRODUCTION ? 'StoryWriter' : IS_STAGING ? 'StoryWriter (Staging)' : 'StoryWriter (Dev)',
     slug: "storywriter",
-    version: "0.5.0",
+    version,
     orientation: "landscape",
     icon: "./assets/images/icon.png",
     scheme: "storywriter",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check:watch": "tsc --noEmit --watch",
     "lint": "tsc --noEmit && expo lint",
     "validate": "npm run type-check && npm run test",
+    "preversion": "npm run validate",
     "build:web": "expo export --platform web"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- `app.config.js` hardcoded `version: "0.5.0"` while `package.json` said `1.0.0`. The Expo config now reads the version from `package.json`, so the two can never drift again.
- Added a `preversion` script (`npm run validate`) so `npm version patch|minor|major` — which bumps `package.json`, commits, and creates the matching `vX.Y.Z` git tag in one step — runs type-check + tests before tagging. The git tag is thereby always minted from the same number the app ships with.
- Decision per Fizzy card #63: current main is v1.0.0; semver `vX.Y.Z` tags from here on. Actually tagging v1.0.0 is card #64 (after the deploy-workflow rework in #61/#62 merges).

## Test plan
- [x] `npx expo config --type public` resolves `version: '1.0.0'`
- [x] `npm test` — 37/37 passing
- [x] `npm run lint` — clean (tsc + expo lint, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)